### PR TITLE
refactor(schema): move properties into composition

### DIFF
--- a/docs/schema/animated-properties/animated-property.json
+++ b/docs/schema/animated-properties/animated-property.json
@@ -3,23 +3,26 @@
     "type": "object",
     "title": "Multi Dimensional",
     "description": "An animatable property that holds an array of numbers",
-    "properties": {
-        "ix": {
-            "title": "Property Index",
-            "type": "integer"
-        },
-        "a": {
-            "title": "Animated",
-            "description": "Whether the property is animated",
-            "$ref": "#/$defs/helpers/int-boolean",
-            "default": 0
-        },
-        "x": {
-            "title": "Expression",
-            "type": "string"
-        }
-    },
     "allOf": [
+        {
+
+            "properties": {
+                "ix": {
+                    "title": "Property Index",
+                    "type": "integer"
+                },
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "default": 0
+                },
+                "x": {
+                    "title": "Expression",
+                    "type": "string"
+                }
+            }
+        },
         {
             "if": {
                 "properties": {

--- a/docs/schema/animated-properties/keyframe.json
+++ b/docs/schema/animated-properties/keyframe.json
@@ -3,27 +3,29 @@
     "type": "object",
     "title": "Keyframe",
     "description": "",
-    "properties": {
-        "t": {
-            "title": "Time",
-            "type": "number",
-            "default": 0
-        },
-        "h": {
-            "title": "Hold",
-            "$ref": "#/$defs/helpers/int-boolean",
-            "default": 0
-        },
-        "s": {
-            "title": "Value",
-            "description": "Value at this keyframe. Note the if the property is a scalar, keyframe values are still represented as arrays",
-            "type": "array",
-            "items": {
-                "type": "number"
-            }
-        }
-    },
     "allOf": [
+        {
+            "properties": {
+                "t": {
+                    "title": "Time",
+                    "type": "number",
+                    "default": 0
+                },
+                "h": {
+                    "title": "Hold",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "default": 0
+                },
+                "s": {
+                    "title": "Value",
+                    "description": "Value at this keyframe. Note the if the property is a scalar, keyframe values are still represented as arrays",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
         {
             "if": {
                 "properties": {

--- a/docs/schema/animated-properties/position.json
+++ b/docs/schema/animated-properties/position.json
@@ -3,23 +3,25 @@
     "type": "object",
     "title": "Position Property",
     "description": "An animatable property to represent a position in space",
-    "properties": {
-        "ix": {
-            "title": "Property Index",
-            "type": "integer"
-        },
-        "a": {
-            "title": "Animated",
-            "description": "Whether the property is animated",
-            "$ref": "#/$defs/helpers/int-boolean",
-            "default": 0
-        },
-        "x": {
-            "title": "Expression",
-            "type": "string"
-        }
-    },
     "allOf": [
+        {
+            "properties": {
+                "ix": {
+                    "title": "Property Index",
+                    "type": "integer"
+                },
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "default": 0
+                },
+                "x": {
+                    "title": "Expression",
+                    "type": "string"
+                }
+            }
+        },
         {
             "if": {
                 "properties": {

--- a/docs/schema/animated-properties/shape-property.json
+++ b/docs/schema/animated-properties/shape-property.json
@@ -3,23 +3,25 @@
     "type": "object",
     "title": "Shape Property",
     "description": "An animatable property that holds a Bezier",
-    "properties": {
-        "ix": {
-            "title": "Property Index",
-            "type": "integer"
-        },
-        "a": {
-            "title": "Animated",
-            "description": "Whether the property is animated",
-            "$ref": "#/$defs/helpers/int-boolean",
-            "default": 0
-        },
-        "x": {
-            "title": "Expression",
-            "type": "string"
-        }
-    },
     "allOf": [
+        {
+            "properties": {
+                "ix": {
+                    "title": "Property Index",
+                    "type": "integer"
+                },
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "default": 0
+                },
+                "x": {
+                    "title": "Expression",
+                    "type": "string"
+                }
+            }
+        },
         {
             "if": {
                 "properties": {

--- a/docs/schema/helpers/transform.json
+++ b/docs/schema/helpers/transform.json
@@ -3,88 +3,94 @@
     "type": "object",
     "title": "Transform",
     "description": "Layer transform",
-    "properties": {
-        "a": {
-            "title": "Anchor Point",
-            "description": "Anchor point: a position (relative to its parent) around which transformations are applied (ie: center for rotation / scale)",
-            "$ref": "#/$defs/animated-properties/position"
-        },
-        "s": {
-            "title": "Scale",
-            "description": "Scale factor, `[100, 100]` for no scaling",
-            "$ref": "#/$defs/animated-properties/multi-dimensional"
-        },
-        "o": {
-            "title": "Opacity",
-            "$ref": "#/$defs/animated-properties/value"
-        },
-        "sk": {
-            "title": "Skew",
-            "description": "Skew amount as an angle in degrees",
-            "$ref": "#/$defs/animated-properties/value"
-        },
-        "sa": {
-            "title": "Skew Axis",
-            "description": "Direction along which skew is applied, in degrees (`0` skews along the X axis, `90` along the Y axis)",
-            "$ref": "#/$defs/animated-properties/value"
-        },
-        "or": {
-            "title": "Orientation",
-            "$ref": "#/$defs/animated-properties/multi-dimensional"
-        }
-    },
-    "anyOf": [
+    "allOf": [
         {
-            "oneOf": [
-                {
-                    "properties":  {
-                        "p": {
-                            "title": "Position",
-                            "description": "Position / Translation",
-                            "$ref": "#/$defs/animated-properties/position"
-                        }
-                    }
+            "properties": {
+                "a": {
+                    "title": "Anchor Point",
+                    "description": "Anchor point: a position (relative to its parent) around which transformations are applied (ie: center for rotation / scale)",
+                    "$ref": "#/$defs/animated-properties/position"
                 },
-                {
-                    "properties":  {
-                        "p": {
-                            "title": "Position",
-                            "description": "Position / Translation with split components",
-                            "$ref": "#/$defs/animated-properties/split-vector"
-                        }
-                    }
+                "s": {
+                    "title": "Scale",
+                    "description": "Scale factor, `[100, 100]` for no scaling",
+                    "$ref": "#/$defs/animated-properties/multi-dimensional"
+                },
+                "o": {
+                    "title": "Opacity",
+                    "$ref": "#/$defs/animated-properties/value"
+                },
+                "sk": {
+                    "title": "Skew",
+                    "description": "Skew amount as an angle in degrees",
+                    "$ref": "#/$defs/animated-properties/value"
+                },
+                "sa": {
+                    "title": "Skew Axis",
+                    "description": "Direction along which skew is applied, in degrees (`0` skews along the X axis, `90` along the Y axis)",
+                    "$ref": "#/$defs/animated-properties/value"
+                },
+                "or": {
+                    "title": "Orientation",
+                    "$ref": "#/$defs/animated-properties/multi-dimensional"
                 }
-            ]
+            }
         },
         {
-            "oneOf": [
+            "anyOf": [
                 {
-                    "properties":  {
-                        "r": {
-                            "title": "Rotation",
-                            "description": "Rotation in degrees, clockwise",
-                            "$ref": "#/$defs/animated-properties/value"
+                    "oneOf": [
+                        {
+                            "properties":  {
+                                "p": {
+                                    "title": "Position",
+                                    "description": "Position / Translation",
+                                    "$ref": "#/$defs/animated-properties/position"
+                                }
+                            }
+                        },
+                        {
+                            "properties":  {
+                                "p": {
+                                    "title": "Position",
+                                    "description": "Position / Translation with split components",
+                                    "$ref": "#/$defs/animated-properties/split-vector"
+                                }
+                            }
                         }
-                    }
+                    ]
                 },
                 {
-                    "properties":  {
-                        "rx": {
-                            "title": "X Rotation",
-                            "description": "Split rotation component",
-                            "$ref": "#/$defs/animated-properties/value"
+                    "oneOf": [
+                        {
+                            "properties":  {
+                                "r": {
+                                    "title": "Rotation",
+                                    "description": "Rotation in degrees, clockwise",
+                                    "$ref": "#/$defs/animated-properties/value"
+                                }
+                            }
                         },
-                        "ry": {
-                            "title": "Y Rotation",
-                            "description": "Split rotation component",
-                            "$ref": "#/$defs/animated-properties/value"
-                        },
-                        "rz": {
-                            "title": "Z Rotation",
-                            "description": "Split rotation component, equivalent to `r` when not split",
-                            "$ref": "#/$defs/animated-properties/value"
+                        {
+                            "properties":  {
+                                "rx": {
+                                    "title": "X Rotation",
+                                    "description": "Split rotation component",
+                                    "$ref": "#/$defs/animated-properties/value"
+                                },
+                                "ry": {
+                                    "title": "Y Rotation",
+                                    "description": "Split rotation component",
+                                    "$ref": "#/$defs/animated-properties/value"
+                                },
+                                "rz": {
+                                    "title": "Z Rotation",
+                                    "description": "Split rotation component, equivalent to `r` when not split",
+                                    "$ref": "#/$defs/animated-properties/value"
+                                }
+                            }
                         }
-                    }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
Separating default `properties` with the properties defined inside composition keywords (`anyOf`, `allOf` & `oneOf`) is valid syntax, but this approach doesn't well suported by type-generator tools such as https://github.com/bcherny/json-schema-to-typescript and https://github.com/quicktype/quicktype, especially with a complex schema with many nested layers. Thus, can we please tweak the syntax a bit and combine all properties together when composition keywords have been used? It's more verbose but IMO also easier to understand what is going on