### PR TITLE
fix: Publish PR Workflow after #13

### DIFF
--- a/docs/animation.md
+++ b/docs/animation.md
@@ -9,10 +9,10 @@ Most of the contents are in [`layers`](layers.md) and [`assets`](assets.md).
 {schema_object:animation/animation}
 EXPAND:#/$defs/animation/composition
 EXPAND:#/$defs/helpers/visual-object
+EXPAND:#/$defs/helpers/three-dimensional
 assets: An array of [assets](assets.md)
 layers: An array of [layers](layers.md) (See: [Lists of layers and shapes](concepts.md#lists-of-layers-and-shapes))
 v: Lottie version, on very old versions some things might be slightly different from what is explained here
-ddd: Whether the animation has 3D layers. Lottie doesn't actually support 3D stuff so this should always be 0
 
 ## Metadata
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -27,7 +27,7 @@ Each layer type has its own properties but there are several common properties:
 {schema_object:layers/visual-layer}
 EXPAND:#/$defs/helpers/visual-object
 EXPAND:#/$defs/layers/layer
-ddd:Whether the layer is 3D. Lottie doesn't actually support 3D stuff so this should always be 0
+EXPAND:#/$defs/helpers/three-dimensional
 ty:Layer type, must be one of the values seen above
 ind:Layer index for [parenting](#parenting)
 parent:Parent index for [parenting](#parenting)

--- a/docs/schema/helpers/three-dimensional.json
+++ b/docs/schema/helpers/three-dimensional.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Whether the layer is three dimensional",
     "type": "object",
     "properties": {
         "ddd": {
             "title": "Three Dimensional",
+            "description": "Whether the animation has 3D layers. Lottie doesn't actually support 3D stuff so this should always be 0",
             "default": 0,
             "$ref": "#/$defs/helpers/int-boolean"
         }

--- a/docs/schema/helpers/three-dimensional.json
+++ b/docs/schema/helpers/three-dimensional.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "Threedimensional",
     "description": "Whether the layer is three dimensional",
     "type": "object",
     "properties": {
         "ddd": {
+            "title": "Three Dimensional",
             "default": 0,
             "$ref": "#/$defs/helpers/int-boolean"
         }

--- a/tools/md_extensions.py
+++ b/tools/md_extensions.py
@@ -308,6 +308,8 @@ def ref_links(ref: str, data: SchemaData):
             return []
         elif link.cls == "marker":
             link.page = "animation"
+        elif link.cls == "three-dimensional":
+            link.anchor = "booleans"
 
     elif link.group == "effect-values":
         link.page = "effects"


### PR DESCRIPTION
The PR Checks Workflow has been [failing](https://github.com/LottieFiles/lottie-docs/runs/4457186806?check_suite_focus=true) after we merged #13, it seems that the https://github.com/LottieFiles/lottie-docs/blob/main/tools/generate-blockly.py requires that every child object (and all their children) must have a title?

TODO:
- [x] fix generate-blockly label error
- [x] fix the new workflow error related to `'ddd'` and `animated.md`
- [x] fix validate_links