### PR TITLE
fix(playground): 🐛 dotLottie canvas element size

### DIFF
--- a/docs/scripts/lottie_raw_utils.js
+++ b/docs/scripts/lottie_raw_utils.js
@@ -118,8 +118,8 @@ class DotLottieWrapper
         if ( options.animationData !== undefined )
         {
             dl_options.data = JSON.stringify(options.animationData);
-            this.canvas.style.width = `${options.animationData.w}px`;
-            this.canvas.style.height = `${options.animationData.h}px`;
+            this.canvas.style.width = "100%";
+            this.canvas.style.height = "100%";
         }
         else
         {


### PR DESCRIPTION
This fix ensures that the size of the dotLottie canvas element does not exceed that of its parent div, addressing the following issue:

<img width="300" alt="image" src="https://github.com/LottieFiles/lottie-docs/assets/39750790/e069edae-0a99-4bcc-8b78-9143d5d2ba87">